### PR TITLE
chore(ci): replace deprecated save-output commands

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
 - name: Save state 1
-  run: echo "::save-state name=state1::value1"
+  run: echo "state1=value1" >> "$GITHUB_STATE"
 
 - name: Set output
   run: echo "::set-output name=output1::value3"
 
 - name: Save state 2
-  run: echo "::save-state name=state2::value2"
+  run: echo "state2=value2" >> "$GITHUB_STATE"

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,8 +1,8 @@
 - name: Save state 1
-  run: echo "::save-state name=state1::value1"
+  run: echo "state1=value1" >> "$GITHUB_STATE"
 
 - name: Set output
   run: echo "::set-output name=output1::value3"
 
 - name: Save state 2
-  run: echo "::save-state name=state2::value2"
+  run: echo "state2=value2" >> "$GITHUB_STATE"


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/