### PR TITLE
chore(ci): replace deprecated set-output commands

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@
   run: echo "::save-state name=state1::value1"
 
 - name: Set output
-  run: echo "::set-output name=output1::value3"
+  run: echo "output1=value3" >> "$GITHUB_OUTPUT"
 
 - name: Save state 2
   run: echo "::save-state name=state2::value2"

--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -2,7 +2,7 @@
   run: echo "::save-state name=state1::value1"
 
 - name: Set output
-  run: echo "::set-output name=output1::value3"
+  run: echo "output1=value3" >> "$GITHUB_OUTPUT"
 
 - name: Save state 2
   run: echo "::save-state name=state2::value2"


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/